### PR TITLE
-fPIC compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ categories = ["science"]
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.53.1"
+bindgen = "*"

--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,13 @@ fn build_wfa() -> Option<()> {
         .output()
         .unwrap();
 
+    // hotfix Makefile
+    let _makefile_fix = Command::new("sed")
+        .arg("-i")
+        .arg("s/CC_FLAGS=-Wall -g/CC_FLAGS=-Wall -g -fPIC/g")
+        .output()
+        .unwrap();
+
     let output = Command::new("make")
         .arg("clean")
         .arg("all")


### PR DESCRIPTION
Adds -fPIC flag during compilation of WFA. Needed on my cluster to avoid issue https://github.com/chfi/rs-wfa/issues/3. Seems other people need it too (https://github.com/pangenome/rs-wfa/commit/079fde1367b08c27d473a7a7c5d8cad1d066d720)